### PR TITLE
Add better testing support

### DIFF
--- a/operations/arguments.py
+++ b/operations/arguments.py
@@ -51,3 +51,10 @@ MONITOR_METRIC_ARGUMENT = {
     'default': MetricType.F1ScoreDilated,
     'required': False,
 }
+NO_LABELS_ARGUMENT = {
+    'name': ['--no_labels'],
+    'help': 'Whether this dataset has labels. When this flag is provided, the dataset will be supplemented using empty labels.',
+    'default': False,
+    'required': False,
+    'action': 'store_true'
+}

--- a/operations/arguments.py
+++ b/operations/arguments.py
@@ -58,3 +58,10 @@ NO_LABELS_ARGUMENT = {
     'required': False,
     'action': 'store_true'
 }
+VISUALIZE_COMPARISONS_ARGUMENT = {
+    'name': ['--visualize_comparisons'],
+    'help': 'Whether to visualize the predictions as a comparison between the ground truth and the predicted label.',
+    'default': False,
+    'required': False,
+    'action': 'store_true'
+}

--- a/operations/implementation/test.py
+++ b/operations/implementation/test.py
@@ -1,18 +1,17 @@
-import os
 from typing import Any, Union
 
 from operations.operation import Operation
 import operations.arguments as arguments
 from network.model import load_model
 from util.hdf5 import HDF5DatasetGenerator
-from util.visualize import visualize_prediction_comparisons
+from util.visualize import visualize_prediction_comparisons, save_predictions
 from util.config import load_network_config, load_data_config, load_output_config
 
 
 class Test(Operation):
     """Operation which tests a trained network"""
 
-    def __call__(self, dataset: str, network: str, weights: Union[str, None], dilate: bool) -> None:
+    def __call__(self, dataset: str, network: str, weights: Union[str, None], dilate: bool, visualize_comparisons: bool) -> None:
         """Generate the predictions given a specific configuration."""
         network_config = load_network_config(network)
         dataset_config = load_data_config(dataset)
@@ -37,8 +36,11 @@ class Test(Operation):
             verbose=1
         )
 
-        # Plot the output
-        visualize_prediction_comparisons(predictions, output_config, dilate)
+        # Plot or just save the output
+        if visualize_comparisons:
+            visualize_prediction_comparisons(predictions, output_config, dilate)
+        else:
+            save_predictions(predictions, output_config)
 
     def get_cli_arguments(self) -> list[dict[str, Any]]:
         return [
@@ -46,4 +48,5 @@ class Test(Operation):
             arguments.DATASET_ARGUMENT,
             arguments.WEIGHTS_FILE_ARGUMENT,
             arguments.DILATE_VALIDATION_LABELS_ARGUMENT,
+            arguments.VISUALIZE_COMPARISONS_ARGUMENT,
         ]

--- a/util/visualize.py
+++ b/util/visualize.py
@@ -12,7 +12,14 @@ from util.hdf5 import IMAGES_KEY, LABELS_KEY
 BINARIZATION_THRESHOLD = 0.5
 LABEL_COLOR = 0.5
 
-def visualize_prediction_comparisons(predictions: tf.Tensor, output_config: OutputConfig, dilate_labels: bool):
+def save_predictions(predictions: tf.Tensor, output_config: OutputConfig) -> None:
+    """Save the predictions plainly as just images."""
+    for idx, prediction in enumerate(predictions):
+        prediction = tf.cast((prediction > BINARIZATION_THRESHOLD) * 255 * LABEL_COLOR, tf.uint8)
+        img = tf.keras.preprocessing.image.array_to_img(prediction, scale=False)
+        img.save(os.path.join(output_config.predictions_dir, f'{idx}.png'))
+
+def visualize_prediction_comparisons(predictions: tf.Tensor, output_config: OutputConfig, dilate_labels: bool) -> None:
     """Visualize the predictions into a comparison between the image, the ground truth and the predicted label."""
 
     data_file = h5py.File(output_config.validation_set_file, 'r')


### PR DESCRIPTION
Add support for better testing by allowing basically empty datasets (such that you can simply test some images without labels) as well as output the predicted labels by default (such that labels are not always necessary anymore, true inference)

# Changes

1. Add new `--no_labels` argument for `build`, which can be used to create a validation set consisting of only images and no labels.
2. Add new `visualize_comparisons` argument for `test`, which returns the predictions as before. The default behaviour is now to just return the predicted labels. 