### PR TITLE
Fixes and adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ This is a fork of the [crack_detection_CNN_masonry repoistory](https://github.co
 * Add better generalizability through the use of configuration files and enhanced dataset support. Add support for more segmentation models.
 * Dependency cleanup: clearly indicate all dependencies through a `requirements.txt` file and make the framework compatible with modern Tensorflow.
 * Add QOL features such as test set creation and resuming training.
+* Fix errors in the original code.
 
 For changes compared to the original repo, please have a look at the [PR descriptions](https://github.com/DavidHidde/CNN-masonry-crack-tasks/pulls?q=is%3Apr+is%3Aclosed+). The main changes include:
 
-* Focal loss computation now uses the Tensorflow implementation rather than a custom implementation.
+* Standardized loss computations. Dice, focal and WCE loss now utilize the direct formulas or Keras/TF functionality.
+* Fixes F1-score computation. The original repo can have F1-scores above 1 if dilated due to an error in the computation.
 * Unet now only uses the segmentation models variant rather than a custom one depending on the use of a backbone. The Unet parameters have also been updated to use transpose layers in the decoder, matching the paper.
 * DeepCrack uses a new [implementation](https://github.com/DavidHidde/DeepCrack-Tensorflow).
-* Newer package versions, meaning that some things might be slightly different.
+* Newer package versions, making the code compatible with modern systems and Python versions.
 
 Overall, the core functionality is retained but updated to work with modern setups, be more flexible as well as maintainable. Some results might differ from the original paper, but it is clear that the forked repo does not fully represent the original paper due to its broken state and lack of crack classification support.
 
@@ -133,7 +135,4 @@ The following codes are based on material provided by **[Adrian Rosebrock](linke
 - Adrian Rosebrock, Keras: Starting, stopping, and resuming training, PyImageSearch, https://www.pyimagesearch.com/2019/09/23/keras-starting-stopping-and-resuming-training/, accessed on 24 February 2021  
 - Adrian Rosebrock, How to use Keras fit and fit_generator (a hands-on tutorial), PyImageSearch, https://www.pyimagesearch.com/2018/12/24/how-to-use-keras-fit-and-fit_generator-a-hands-on-tutorial/, accessed on 24 February 2021  
 
-The Segmentation Models with pre-trained CNNs are implemented based on the work of **[Pavel Yakubovskiy](https://github.com/qubvel)** and his GitHub Repository https://github.com/qubvel/segmentation_models  
-
-The Weighted Cross-Entropy (WCE) Loss is based on the implementation found in the link below:  
-https://jeune-research.tistory.com/entry/Loss-Functions-for-Image-Segmentation-Distribution-Based-Losses
+The Segmentation Models with pre-trained CNNs are implemented based on the work of **[Pavel Yakubovskiy](https://github.com/qubvel)** and his GitHub Repository https://github.com/qubvel/segmentation_models

--- a/network/loss/__init__.py
+++ b/network/loss/__init__.py
@@ -1,8 +1,9 @@
 from typing import Callable
 
 import tensorflow as tf
+import keras
 
-from network.loss.loss_functions import weighted_cross_entropy, f1_score_loss
+from network.loss.loss_functions import weighted_binary_cross_entropy, dilated_dice_loss
 from util.config.network_config import NetworkConfig
 from util.types import LossType
 
@@ -19,10 +20,10 @@ def determine_loss_function(config: NetworkConfig) -> Callable[[tf.Tensor, tf.Te
         case LossType.BCE:
             return tf.keras.losses.BinaryCrossentropy()
         case LossType.WCE:
-            return weighted_cross_entropy(WCE_BETA)
+            return weighted_binary_cross_entropy(WCE_BETA)
         case LossType.F1Score:
-            return f1_score_loss(False)
+            return keras.losses.Dice()
         case LossType.F1ScoreDilate:
-            return f1_score_loss(True)
+            return dilated_dice_loss
         case _:
             raise ValueError(f'Unknown loss type: {config.loss}')

--- a/network/metrics/metric_functions.py
+++ b/network/metrics/metric_functions.py
@@ -1,20 +1,23 @@
 import tensorflow as tf
 import tensorflow.keras.backend as K
+from keras.src import ops
 
 from util.image_operations import dilation2d
 
 DILATION_KERNEL_SIZE = 5
 
+def clip_sum(tensor: tf.Tensor) -> float:
+    """Clip the values between 0 and 1 and then sum them."""
+    return ops.sum(tf.clip_by_value(tensor, K.epsilon() , 1. - K.epsilon()))
+
 def recall(y_true: tf.Tensor, y_pred: tf.Tensor, dilate=False) -> float:
     """
     Recall = TP / (TP + FN). Dilate label if requested.
     """
-    if dilate:
-        y_true = dilation2d(y_true, DILATION_KERNEL_SIZE)
+    tp = clip_sum(dilation2d(y_true, DILATION_KERNEL_SIZE) * y_pred if dilate else y_true * y_pred)
+    fn = clip_sum(y_true - y_pred)
 
-    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
-    gt_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
-    return true_positives / (gt_positives + K.epsilon())
+    return tp / (tp + fn + K.epsilon())
 
 def precision(y_true: tf.Tensor, y_pred: tf.Tensor, dilate=False) -> float:
     """
@@ -23,14 +26,25 @@ def precision(y_true: tf.Tensor, y_pred: tf.Tensor, dilate=False) -> float:
     if dilate:
         y_true = dilation2d(y_true, DILATION_KERNEL_SIZE)
 
-    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
-    predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
-    return true_positives / (predicted_positives + K.epsilon())
+    tp = clip_sum(y_true * y_pred)
+    predicted_positives = clip_sum(y_pred)
+    return tp / (predicted_positives + K.epsilon())
 
 def f1_score(y_true: tf.Tensor, y_pred: tf.Tensor, dilate=False) -> float:
-    precision_val = precision(y_true, y_pred, dilate)
-    recall_val = recall(y_true, y_pred)
-    return 2 * ((precision_val * recall_val) / (precision_val + recall_val + K.epsilon()))
+    """
+    F1-score = 2TP / (2TP + FP + FN). Dilate label if requested.
+    """
+    if dilate:
+        y_true_dilated = dilation2d(y_true, DILATION_KERNEL_SIZE)
+        tp = clip_sum(y_true_dilated * y_pred)
+        fp = clip_sum(y_pred - y_true_dilated)
+    else:
+        tp = clip_sum(y_true * y_pred)
+        fp = clip_sum(y_pred - y_true)
+
+    fn = clip_sum(y_true - y_pred)
+
+    return (2. * tp) / (2. * tp + fp + fn + K.epsilon())
 
 # Macros for Keras metrics. Don't use the functions aside from that
 def precision_dilated(y_true: tf.Tensor, y_pred: tf.Tensor) -> float:

--- a/network/model/build_model.py
+++ b/network/model/build_model.py
@@ -15,7 +15,7 @@ FPN_BLOCK_FILTERS = 512
 
 UNET_NUM_FILTERS = 64
 UNET_DECODER_FILTERS = (1024, 512, 256, 128, 64)
-UNET_DECODER_BLOCK_TYPE = 'transpose'
+UNET_DECODER_BLOCK_TYPE = 'upsampling'
 
 PSP_CONV_FILTERS = 512
 
@@ -62,7 +62,7 @@ def build_model(network_config: NetworkConfig, input_dims: tuple[int, int, int])
         'encoder_weights': 'imagenet' if network_config.use_pretrained else None,
     }
     if network_config.backbone is not None:
-        sm_model_kwargs['backbone_name']: network_config.backbone.value
+        sm_model_kwargs['backbone_name'] = network_config.backbone.value
 
     match network_config.model:
         case ModelType.DeepCrack:

--- a/operations/implementation/test.py
+++ b/operations/implementation/test.py
@@ -4,7 +4,7 @@ from operations.operation import Operation
 import operations.arguments as arguments
 from network.model import load_model
 from util.hdf5 import HDF5DatasetGenerator
-from util.visualize import visualize_prediction_comparisons, save_predictions
+from util.visualize import visualize_prediction_comparisons, save_predictions, print_prediction_metrics
 from util.config import load_network_config, load_data_config, load_output_config
 
 
@@ -35,6 +35,7 @@ class Test(Operation):
             max_queue_size=network_config.batch_size * 2,
             verbose=1
         )
+        print_prediction_metrics(predictions, output_config, dilate)
 
         # Plot or just save the output
         if visualize_comparisons:

--- a/operations/implementation/test.py
+++ b/operations/implementation/test.py
@@ -1,10 +1,13 @@
 from typing import Any, Union
 
+from network.loss import determine_loss_function
+from network.metrics import get_standard_metrics
+from network.optimizer import determine_optimizer
 from operations.operation import Operation
 import operations.arguments as arguments
 from network.model import load_model
 from util.hdf5 import HDF5DatasetGenerator
-from util.visualize import visualize_prediction_comparisons, save_predictions, print_prediction_metrics
+from util.visualize import visualize_prediction_comparisons, save_predictions
 from util.config import load_network_config, load_data_config, load_output_config
 
 
@@ -18,6 +21,11 @@ class Test(Operation):
         output_config = load_output_config(network_id=network_config.id, dataset_id=dataset_config.dataset_dir)
 
         model = load_model(network_config, output_config, dataset_config.image_dims, weights)
+        model.compile(
+            optimizer=determine_optimizer(network_config),
+            loss=determine_loss_function(network_config),
+            metrics=[get_standard_metrics()]
+        )
 
         # Do not use data augmentation when evaluating model: aug=None
         eval_gen = HDF5DatasetGenerator(
@@ -35,7 +43,16 @@ class Test(Operation):
             max_queue_size=network_config.batch_size * 2,
             verbose=1
         )
-        print_prediction_metrics(predictions, output_config, dilate)
+        metrics = model.evaluate(
+            eval_gen(),
+            steps=eval_gen.num_images // network_config.batch_size + 1,
+            verbose=1,
+            return_dict=True
+        )
+        print('\n--- Results ---')
+        for key, value in metrics.items():
+            print(f'{key}: {(value * 100):.2f}')
+        print('---------------\n')
 
         # Plot or just save the output
         if visualize_comparisons:

--- a/operations/implementation/train.py
+++ b/operations/implementation/train.py
@@ -39,7 +39,7 @@ class Train(Operation):
             model = load_model(network_config, output_config, dataset_config.image_dims, weights)
 
             # Determine start epoch. We assume the file follows the regular naming scheme (epoch_X_*.)
-            parts = weights.split('_')
+            parts = weights.split(os.path.sep)[-1].split('_')
             for idx, part in enumerate(parts):
                 if part == 'epoch':
                     start_epoch = int(parts[idx + 1])

--- a/operations/implementation/train.py
+++ b/operations/implementation/train.py
@@ -83,7 +83,7 @@ class Train(Operation):
             network_config.batch_size,
             False,
             network_config.binarize_labels,
-            data_augmentor
+            None
         )
 
         # Serialize model to JSON

--- a/util/visualize.py
+++ b/util/visualize.py
@@ -12,6 +12,21 @@ from util.hdf5 import IMAGES_KEY, LABELS_KEY
 BINARIZATION_THRESHOLD = 0.5
 LABEL_COLOR = 0.5
 
+def print_prediction_metrics(predictions: tf.Tensor, output_config: OutputConfig, dilate_labels: bool) -> None:
+    """Print the F1-score, recall and precision over the entire validation set."""
+    data_file = h5py.File(output_config.validation_set_file, 'r')
+    labels = tf.convert_to_tensor(np.array(data_file[LABELS_KEY][:]), dtype=tf.float32)
+
+    recall_value = float(recall(labels, predictions, dilate_labels))
+    precision_value = float(precision(labels, predictions, dilate_labels))
+    f1_score_value = float(f1_score(labels, predictions, dilate_labels))
+
+    print(f'''
+Precision: {precision_value:.3f},
+Recall: {recall_value:.3f},
+F1-score: {f1_score_value:.3f}
+    ''')
+
 def save_predictions(predictions: tf.Tensor, output_config: OutputConfig) -> None:
     """Save the predictions plainly as just images."""
     for idx, prediction in enumerate(predictions):

--- a/util/visualize.py
+++ b/util/visualize.py
@@ -12,21 +12,6 @@ from util.hdf5 import IMAGES_KEY, LABELS_KEY
 BINARIZATION_THRESHOLD = 0.5
 LABEL_COLOR = 0.5
 
-def print_prediction_metrics(predictions: tf.Tensor, output_config: OutputConfig, dilate_labels: bool) -> None:
-    """Print the F1-score, recall and precision over the entire validation set."""
-    data_file = h5py.File(output_config.validation_set_file, 'r')
-    labels = tf.convert_to_tensor(np.array(data_file[LABELS_KEY][:]), dtype=tf.float32)
-
-    recall_value = float(recall(labels, predictions, dilate_labels))
-    precision_value = float(precision(labels, predictions, dilate_labels))
-    f1_score_value = float(f1_score(labels, predictions, dilate_labels))
-
-    print(f'''
-Precision: {precision_value:.3f},
-Recall: {recall_value:.3f},
-F1-score: {f1_score_value:.3f}
-    ''')
-
 def save_predictions(predictions: tf.Tensor, output_config: OutputConfig) -> None:
     """Save the predictions plainly as just images."""
     for idx, prediction in enumerate(predictions):


### PR DESCRIPTION
Fixes the models, corrects the metrics/loss functions and some more. The changes from this PR do change how some loss functions are calculated and **most importantly how the metrics function**. Previously, the F1-score was computed as follows:

$\text{F1-score}(gt,\ pred)\ =\ 2 \frac{dilation(gt) \cdot pred}{\sum gt + \sum pred}$

where "gt" is the ground truth labels and "pred" the predicted labels. The problems with this is that when expanded, the numerator can contain more pixels compared to the denominator, leading to higher values than 1. This is adjusted by simply directly using the TP, FP and FN values rather than the sum trick, which restores the score to the range [0, 1].

## Changes

1. Update F1-score calculation (for loss and metrics) to properly adjust for dilation.
2. Replace regular F1-score loss with Keras dice loss. Adjust dilated dice loss to resemble the same code structure.
3. Change WCE loss to directly calculate the loss from the output rather than use the TF function with logits.
4. Fix backbones not loading for `sm` models.
5. Add metrics in `test` operation output.
6. Remove data augmentations to the validation dataset generator, as it does not make sense to test on modified images.
7. Fix weight files not being loadable from an absolute path. 